### PR TITLE
Removing repeated code in Tests

### DIFF
--- a/test/amp_test.exs
+++ b/test/amp_test.exs
@@ -4,9 +4,7 @@ defmodule AmpTest do
     md_ext_to_html: 1,
     remove_white_space: 1,
     read_markdown: 1,
-    read_amp_html_no_config: 1,
-    read_amp_html_head_override: 1,
-    read_amp_html_empty_opts: 1
+    read: 2
   ]
 
   test "Renders a h1 tag" do
@@ -14,8 +12,16 @@ defmodule AmpTest do
     assert html =~ "<h1>Hello World</h1>"
   end
 
-  describe "fixtures" do
-    test "no config" do
+  test "fixtures" do
+    [{"no_config", %{}},
+     {"head_override", %{head_override: ""}},
+     {"empty_opts",
+       %{canonical_url: "",
+         style: "",
+         title: "",
+         extra_head_html: ""
+       }},
+    ] |> Enum.each(fn {folder, opts} ->
       {:ok, markdown_files} = File.ls("test/fixtures/markdown")
 
       Enum.each(markdown_files, fn markdown_file ->
@@ -27,64 +33,15 @@ defmodule AmpTest do
 
         {:ok, markdown} = read_markdown(markdown_file)
 
-        {:ok, actual_html, []} = Amp.parse(markdown)
-        {:ok, expected_html} = read_amp_html_no_config(amp_html_file)
-
-        actual = remove_white_space(actual_html)
-        expected = remove_white_space(expected_html)
-
-        assert actual == expected
-      end)
-    end
-
-    test "head_override" do
-      {:ok, markdown_files} = File.ls("test/fixtures/markdown")
-
-      Enum.each(markdown_files, fn markdown_file ->
-        # e.g.
-        # markdown_file == hello_world.md
-        # amp_html_file == hello_world.html
-
-        amp_html_file = md_ext_to_html(markdown_file)
-
-        {:ok, markdown} = read_markdown(markdown_file)
-
-        {:ok, actual_html, []} = Amp.parse(markdown, %{head_override: ""})
-        {:ok, expected_html} = read_amp_html_head_override(amp_html_file)
-
-        actual = remove_white_space(actual_html)
-        expected = remove_white_space(expected_html)
-
-        assert actual == expected
-      end)
-    end
-
-    test "canonical_url, style, title, extra_head_html" do
-      {:ok, markdown_files} = File.ls("test/fixtures/markdown")
-
-      Enum.each(markdown_files, fn markdown_file ->
-        # e.g.
-        # markdown_file == hello_world.md
-        # amp_html_file == hello_world.html
-
-        amp_html_file = md_ext_to_html(markdown_file)
-
-        {:ok, markdown} = read_markdown(markdown_file)
-
-        opts =
-          %{canonical_url: "",
-            style: "",
-            title: "",
-            extra_head_html: ""
-          }
         {:ok, actual_html, []} = Amp.parse(markdown, opts)
-        {:ok, expected_html} = read_amp_html_empty_opts(amp_html_file)
+
+        {:ok, expected_html} = read("amp_html/#{folder}", amp_html_file)
 
         actual = remove_white_space(actual_html)
         expected = remove_white_space(expected_html)
 
         assert actual == expected
       end)
-    end
+    end)
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -12,15 +12,6 @@ defmodule Amp.TestHelpers do
     |> Enum.join("\n")
   end
 
-  defp read(type, file), do: File.read("test/fixtures/#{type}/#{file}")
+  def read(type, file), do: File.read("test/fixtures/#{type}/#{file}")
   def read_markdown(file), do: read("markdown", file)
-  def read_amp_html_no_config(file) do
-    read("amp_html/no_config", file)
-  end
-  def read_amp_html_head_override(file) do
-    read("amp_html/head_override", file)
-  end
-  def read_amp_html_empty_opts(file) do
-    read("amp_html/empty_opts", file)
-  end
 end


### PR DESCRIPTION
In `test/amp_test.exs` there is a bit of repeated code, making it easier to read. Refactoring.